### PR TITLE
Hi Alex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (SOIL)
 
 set (SOIL_BUILD_TESTS false CACHE BOOL "Build tests")
 
-if(ANDROID)
+if(ANDROID OR IOS)
   # Android requires GL ES 2.0 package automatically
   set(LIBRARIES GLESv2)
 else()

--- a/src/SOIL.c
+++ b/src/SOIL.c
@@ -14,9 +14,9 @@
 */
 
 #define SOIL_CHECK_FOR_GL_ERRORS 0
-#define SOIL_USEGLTEXSUBIMAGE2D 1
+#define SOIL_USEGLTEXSUBIMAGE2D 0
 
-#ifdef SOIL_USEGLTEXSUBIMAGE2D
+#if SOIL_USEGLTEXSUBIMAGE2D
 #define SOIL_glTexImage2D( target, level, internalformat, width, height, border, format, type, data ) \
 glTexSubImage2D( target, level, 0, 0, width, height, format, type, data )
 #else

--- a/src/SOIL.c
+++ b/src/SOIL.c
@@ -14,9 +14,9 @@
 */
 
 #define SOIL_CHECK_FOR_GL_ERRORS 0
-#define SOIL_USEGLTEXSUBIMAGE2D 1
+#define SOIL_USEGLTEXSUBIMAGE2D 0
 
-#ifdef SOIL_USEGLTEXSUBIMAGE2D
+#if SOIL_USEGLTEXSUBIMAGE2D
 #define SOIL_glTexImage2D( target, level, internalformat, width, height, border, format, type, data ) \
 glTexSubImage2D( target, level, 0, 0, width, height, format, type, data )
 #else
@@ -35,9 +35,14 @@ glTexImage2D( target, level, internalformat, width, height, border, format, type
 	#include <wingdi.h>
 	#include <GL/gl.h>
 #elif defined(__APPLE__) || defined(__APPLE_CC__)
-	/*	I can't test this Apple stuff!	*/
-	#include <OpenGL/gl.h>
-	#include <Carbon/Carbon.h>
+    #include "TargetConditionals.h"
+	#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+		#include <CoreFoundation/CFBundle.h>
+		#include <OpenGLES/ES1/gl.h>
+	#else
+		#include <OpenGL/gl.h>
+		#include <Carbon/Carbon.h>
+	#endif
 	#define APIENTRY
 #elif defined(__ANDROID__)
 	#include <GLES/gl.h>
@@ -56,6 +61,7 @@ glTexImage2D( target, level, internalformat, width, height, border, format, type
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 /*	error reporting	*/
 char *result_string_pointer = "SOIL initialized";


### PR DESCRIPTION
Please, review and integrate these changes into SOIL

There IOS build support and revoke glTexSubImage2D usage (in Unity used another approach)
